### PR TITLE
docs: add MacPorts installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ timer --help
 brew install caarlos0/tap/timer
 ```
 
+**macports**:
+
+```sh
+sudo port install timer
+```
+
 **snap**:
 
 ```sh


### PR DESCRIPTION
On macOS, `timer` can now be installed through MacPorts: https://ports.macports.org/port/timer/