### PR TITLE
 Allow omitting unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-Timer is a small CLI, similar to the `sleep` everyone already knows and love, 
+Timer is a small CLI, similar to the `sleep` everyone already knows and love,
 with a couple of extra features:
 
 - a progress bar indicating the progression of said timer
@@ -21,6 +21,11 @@ timer -n <name> <duration>
 man timer
 timer --help
 ```
+
+It is possible to pass a time unit for `<duration>`.
+
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+If no unit is passed, it defaults to seconds ("s").
 
 ## Install
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -112,6 +113,7 @@ var rootCmd = &coral.Command{
 	SilenceUsage: true,
 	Args:         coral.ExactArgs(1),
 	RunE: func(cmd *coral.Command, args []string) error {
+		addSuffixIfArgIsNumber(&(args[0]), "s")
 		duration, err := time.ParseDuration(args[0])
 		if err != nil {
 			return err
@@ -154,5 +156,12 @@ func init() {
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
+	}
+}
+
+func addSuffixIfArgIsNumber(s *string, suffix string) {
+	_, err := strconv.ParseFloat(*s, 64)
+	if err == nil {
+		*s = *s + suffix
 	}
 }


### PR DESCRIPTION
Hello and good day. I'm not really sure how to contribute to this project, if I could just open a PR or not, so if this was not OK please let me know and lets close it.

The thing is, I saw an open issue where it was requestes to allow ommiting units, just like the regular sleep command, where it defaults to seconds when no unit is passed. So I did kind of fix to that. I'm not a go programmer, I recently started learning it, so I don't know if my implementation was a good idea or not. I mutated the state of `arg[0]`, this sounds fishy, but I looked like it wasn't used anywhere else.

Anyways, if this is a valid feature (ommiting units), please let me know. And if it is the case, I think it could be stated in the help/manual/readme that it defaults to seconds.

Solves #34