### PR TITLE
WIP feat: added pause

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.interrupting = true
 			return m, tea.Quit
 		}
+		if key.Matches(msg, pauseKeys) {
+			return m, m.timer.Toggle()
+		}
 	}
 
 	return m, nil
@@ -106,6 +109,7 @@ var (
 	version             = "dev"
 	quitKeys            = key.NewBinding(key.WithKeys("esc", "q"))
 	intKeys             = key.NewBinding(key.WithKeys("ctrl+c"))
+	pauseKeys           = key.NewBinding(key.WithKeys(" "))
 	boldStyle           = lipgloss.NewStyle().Bold(true)
 	italicStyle         = lipgloss.NewStyle().Italic(true)
 )


### PR DESCRIPTION
Added a pause option but the timer is always twice as fast after you toggle on and off again. I tried reading the documentation and looked at the example in the bubbletea repo but I don't get why that happens.

Gonna try a little more tomorrow if someone got the answer I would be greatful tho 😄.

Related to issue #57...