### PR TITLE
feat: make gradient colours configurable (#133)

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ var (
 	altscreenStyle  = lipgloss.NewStyle().MarginLeft(padding)
 	boldStyle       = lipgloss.NewStyle().Bold(true)
 	italicStyle     = lipgloss.NewStyle().Italic(true)
-	gradientFlag    string
+	gradient        string
 )
 
 var gradientPresets = map[string][2]string{

--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ var rootCmd = &cobra.Command{
 			progressBar = progress.New(progress.WithGradient(preset[0], preset[1]))
 		} else if strings.Contains(gradientFlag, ",") {
 			parts := strings.SplitN(gradientFlag, ",", 2)
-			progressBar = progress.New(progress.WithGradient(parts[0], parts[1]))
+			progressBar = progress.New(progress.WithGradient(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])))
 		} else {
 			// fallback to default gradient if invalid input
 			progressBar = progress.New(progress.WithDefaultGradient())

--- a/main.go
+++ b/main.go
@@ -120,7 +120,16 @@ var (
 	altscreenStyle  = lipgloss.NewStyle().MarginLeft(padding)
 	boldStyle       = lipgloss.NewStyle().Bold(true)
 	italicStyle     = lipgloss.NewStyle().Italic(true)
+	gradientFlag    string
 )
+
+var gradientPresets = map[string][2]string{
+	"default": {"#5A56E0", "#EE6FF8"},
+	"sunset":  {"#FFB28C", "#FFC371"},
+	"aqua":    {"#13547A", "#80D0C7"},
+	"forest":  {"#5A3F37", "#2C7744"},
+	"fire":    {"#F7971E", "#FFD200"},
+}
 
 const (
 	padding  = 2
@@ -147,10 +156,26 @@ var rootCmd = &cobra.Command{
 		if duration < time.Minute {
 			interval = 100 * time.Millisecond
 		}
+
+		// choose the gradient based on the flag
+		// if the flag is empty or "default", use the default gradient
+		var progressBar progress.Model
+		if gradientFlag == "" || gradientFlag == "default" {
+			progressBar = progress.New(progress.WithDefaultGradient())
+		} else if preset, ok := gradientPresets[gradientFlag]; ok {
+			progressBar = progress.New(progress.WithGradient(preset[0], preset[1]))
+		} else if strings.Contains(gradientFlag, ",") {
+			parts := strings.SplitN(gradientFlag, ",", 2)
+			progressBar = progress.New(progress.WithGradient(parts[0], parts[1]))
+		} else {
+			// fallback to default gradient if invalid input
+			progressBar = progress.New(progress.WithDefaultGradient())
+		}
+
 		m, err := tea.NewProgram(model{
 			duration:        duration,
 			timer:           timer.New(duration, timer.WithInterval(interval)),
-			progress:        progress.New(progress.WithDefaultGradient()),
+			progress:        progressBar,
 			name:            name,
 			altscreen:       altscreen,
 			startTimeFormat: startTimeFormat,
@@ -192,6 +217,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&name, "name", "n", "", "timer name")
 	rootCmd.Flags().BoolVarP(&altscreen, "fullscreen", "f", false, "fullscreen")
 	rootCmd.Flags().StringVarP(&startTimeFormat, "format", "", "", "Specify start time format, possible values: 24h, kitchen")
+	rootCmd.Flags().StringVarP(&gradientFlag, "gradient", "g", "default", "Gradient preset (default, sunset, aqua, forest, fire) or two hex colors separated by comma (ex: --gradient=#00FF00,#0000FF)")
 
 	rootCmd.AddCommand(manCmd)
 }

--- a/main.go
+++ b/main.go
@@ -159,18 +159,15 @@ var rootCmd = &cobra.Command{
 
 		// choose the gradient based on the flag
 		// if the flag is empty or "default", use the default gradient
+		
 		var progressBar progress.Model
-		if gradient == "" || gradient == "default" {
-			progressBar = progress.New(progress.WithDefaultGradient())
-		} else if preset, ok := gradientPresets[gradient]; ok {
-			progressBar = progress.New(progress.WithGradient(preset[0], preset[1]))
+		if preset, ok := gradientPresets[gradient]; ok {
+		  progressBar = progress.New(progress.WithGradient(preset[0], preset[1]))
 		} else if strings.Contains(gradient, ",") {
-			parts := strings.SplitN(gradient, ",", 2)
-			progressBar = progress.New(progress.WithGradient(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])))
+		  parts := strings.SplitN(gradient, ",", 2)
+		  progressBar = progress.New(progress.WithGradient(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])))
 		} else {
-			// fallback to default gradient if invalid input
-			fmt.Printf("Warning: Invalid gradient '%s'. Falling back to default gradient.\n", gradient)
-			progressBar = progress.New(progress.WithDefaultGradient())
+		  return fmt.Errorf("invalid gradient %q", gradient)
 		}
 
 		m, err := tea.NewProgram(model{

--- a/main.go
+++ b/main.go
@@ -169,6 +169,7 @@ var rootCmd = &cobra.Command{
 			progressBar = progress.New(progress.WithGradient(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])))
 		} else {
 			// fallback to default gradient if invalid input
+			fmt.Printf("Warning: Invalid gradient '%s'. Falling back to default gradient.\n", gradientFlag)
 			progressBar = progress.New(progress.WithDefaultGradient())
 		}
 

--- a/main.go
+++ b/main.go
@@ -160,16 +160,16 @@ var rootCmd = &cobra.Command{
 		// choose the gradient based on the flag
 		// if the flag is empty or "default", use the default gradient
 		var progressBar progress.Model
-		if gradientFlag == "" || gradientFlag == "default" {
+		if gradient == "" || gradient == "default" {
 			progressBar = progress.New(progress.WithDefaultGradient())
-		} else if preset, ok := gradientPresets[gradientFlag]; ok {
+		} else if preset, ok := gradientPresets[gradient]; ok {
 			progressBar = progress.New(progress.WithGradient(preset[0], preset[1]))
-		} else if strings.Contains(gradientFlag, ",") {
-			parts := strings.SplitN(gradientFlag, ",", 2)
+		} else if strings.Contains(gradient, ",") {
+			parts := strings.SplitN(gradient, ",", 2)
 			progressBar = progress.New(progress.WithGradient(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])))
 		} else {
 			// fallback to default gradient if invalid input
-			fmt.Printf("Warning: Invalid gradient '%s'. Falling back to default gradient.\n", gradientFlag)
+			fmt.Printf("Warning: Invalid gradient '%s'. Falling back to default gradient.\n", gradient)
 			progressBar = progress.New(progress.WithDefaultGradient())
 		}
 
@@ -218,7 +218,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&name, "name", "n", "", "timer name")
 	rootCmd.Flags().BoolVarP(&altscreen, "fullscreen", "f", false, "fullscreen")
 	rootCmd.Flags().StringVarP(&startTimeFormat, "format", "", "", "Specify start time format, possible values: 24h, kitchen")
-	rootCmd.Flags().StringVarP(&gradientFlag, "gradient", "g", "default", "Gradient preset (default, sunset, aqua, forest, fire) or two hex colors separated by comma (ex: --gradient=#00FF00,#0000FF)")
+	rootCmd.Flags().StringVarP(&gradient, "gradient", "g", "default", "Gradient preset (default, sunset, aqua, forest, fire) or two hex colors separated by comma (ex: --gradient=#00FF00,#0000FF)")
 
 	rootCmd.AddCommand(manCmd)
 }

--- a/main.go
+++ b/main.go
@@ -161,7 +161,8 @@ var rootCmd = &cobra.Command{
 		// if the flag is empty or "default", use the default gradient
 		
 		var progressBar progress.Model
-		if preset, ok := gradientPresets[gradient]; ok {
+		normalizedGradient := strings.ToLower(gradient)
+		if preset, ok := gradientPresets[normalizedGradient]; ok {
 		  progressBar = progress.New(progress.WithGradient(preset[0], preset[1]))
 		} else if strings.Contains(gradient, ",") {
 		  parts := strings.SplitN(gradient, ",", 2)


### PR DESCRIPTION
**Add configurable gradient support for progress bar**

This PR introduces a new `--gradient (-g)` flag that allows users to customize the progress bar gradient. Users can now select from predefined presets (default, sunset, aqua, forest, fire) or specify two custom hex colors separated by a comma (e.g., --gradient=#00FF00,#0000FF). If the flag is not set or an invalid value is provided, the default gradient is used.

**Features:**

New --gradient flag for selecting gradient style.
Support for both presets and custom color pairs.
Updated help text to document the new flag.